### PR TITLE
统一日志到slf4j桥接器统一管理，不再强依赖log4j；排除common-logging，其日志也通过slf4j进行桥接。

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ repositories {
 
 List logger = [
 	"org.slf4j:jul-to-slf4j:1.7.10",
+	"org.slf4j:jcl-over-slf4j:1.7.10",
 	"org.apache.logging.log4j:log4j-api:2.1",
 	"org.apache.logging.log4j:log4j-core:2.1",
 	"org.apache.logging.log4j:log4j-slf4j-impl:2.1",
@@ -41,6 +42,11 @@ List alibaba = [
         'com.alibaba:druid:1.0.29',
         'com.alibaba:fastjson:1.2.29'
 ]
+
+//排除commons-logging，用slf4j替换之。
+configurations.all {
+	exclude group: "commons-logging", module: "commons-logging"
+}
 
 // In this section you declare the dependencies for your production and test code
 dependencies {

--- a/src/main/java/org/bcos/contract/tools/KeyInfo.java
+++ b/src/main/java/org/bcos/contract/tools/KeyInfo.java
@@ -1,29 +1,16 @@
 package org.bcos.contract.tools;
 
-import java.io.*;
-import java.io.InputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-
-import java.util.Map;
-import java.util.HashMap;
-
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
-
 import com.alibaba.fastjson.JSONObject;
-import com.alibaba.fastjson.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import org.bcos.contract.tools.RetCode;
-import org.bcos.contract.tools.KeyInfoInterface;
+import java.io.*;
 
 public class KeyInfo implements KeyInfoInterface {
 	private static String privateKey;
 	private static String publicKey;
 	private static String account;
-	private static Logger logger = LogManager.getLogger(KeyInfo.class);
+	private static Logger logger = LoggerFactory.getLogger(KeyInfo.class);
 
 	public final static String privJsonKey = "privateKey";
 	public final static String pubJsonKey = "publicKey";

--- a/src/main/java/org/bcos/web3j/crypto/GenCredential.java
+++ b/src/main/java/org/bcos/web3j/crypto/GenCredential.java
@@ -1,29 +1,17 @@
 package org.bcos.web3j.crypto;
 
-import org.bcos.web3j.crypto.Credentials;
-
-import org.bcos.web3j.crypto.ECKeyPair;
-import org.bcos.web3j.crypto.Keys;
-import org.bcos.web3j.crypto.Sign;
-import org.bcos.web3j.crypto.EncryptType;
 import org.bcos.web3j.crypto.sm2.crypto.asymmetric.SM2KeyGenerator;
 import org.bcos.web3j.crypto.sm2.crypto.asymmetric.SM2PrivateKey;
 import org.bcos.web3j.crypto.sm2.crypto.asymmetric.SM2PublicKey;
 import org.bcos.web3j.crypto.sm2.util.encoders.Hex;
-
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
-
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.math.BigInteger;
 import java.security.KeyPair;
-import java.util.UUID;
 
 public class GenCredential {
-	private static Logger logger = LogManager.getLogger(GenCredential.class);
+	private static Logger logger = LoggerFactory.getLogger(GenCredential.class);
 
 	public static ECKeyPair createGuomiKeyPair() {
 		System.out.println("=====INIT GUOMI KEYPAIR ====");

--- a/src/test/resources/applicationContext.xml
+++ b/src/test/resources/applicationContext.xml
@@ -1,15 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
-	xmlns:tx="http://www.springframework.org/schema/tx" xmlns:aop="http://www.springframework.org/schema/aop"
-	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans   
-    http://www.springframework.org/schema/beans/spring-beans-2.5.xsd  
-         http://www.springframework.org/schema/tx   
-    http://www.springframework.org/schema/tx/spring-tx-2.5.xsd  
-         http://www.springframework.org/schema/aop   
-    http://www.springframework.org/schema/aop/spring-aop-2.5.xsd">
+    http://www.springframework.org/schema/beans/spring-beans.xsd ">
+
     <bean id="pool" class="org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor">
 		<property name="corePoolSize" value="50" />
 		<property name="maxPoolSize" value="100" />

--- a/src/test/resources/commons-logging.properties
+++ b/src/test/resources/commons-logging.properties
@@ -1,1 +1,0 @@
-org.apache.commons.logging.Log=org.apache.commons.logging.impl.SimpleLog

--- a/src/test/resources/simplelog.properties
+++ b/src/test/resources/simplelog.properties
@@ -1,7 +1,0 @@
-org.apache.commons.logging.simplelog.defaultlog=warn
-#trace
-#debug
-#info
-#warn
-#error
-#fatal


### PR DESCRIPTION
解耦log4j依赖，统一依赖slf4j，方便使用其他日志实现。