### PR TITLE
兼容filesystem读取证书文件

### DIFF
--- a/src/main/java/org/bcos/channel/handler/ChannelConnections.java
+++ b/src/main/java/org/bcos/channel/handler/ChannelConnections.java
@@ -56,19 +56,20 @@ public class ChannelConnections {
 		this.caCertPath = caCertPath;
 	}
 	
-	public InputStream getInputStream(String filePath) throws IOException{
-	    // if starts with "classpath:"
-	    if(filePath.startsWith("classpath:")){
-	        ResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
-	        Resource caResource = resolver.getResource(filePath);
-	        return caResource.getInputStream();
-	    }
-	    else{
-            File file = new File(filePath); 
-            InputStream inputStream = new FileInputStream(file);
-            return inputStream;
-	    }
-	}
+	public InputStream getInputStream(String filePath) throws IOException {
+        if (filePath.startsWith("classpath:") || filePath.startsWith("file:")) {
+            ResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+            Resource caResource = resolver.getResource(filePath);
+            try (InputStream inputStream = caResource.getInputStream()) {
+                return inputStream;
+            }
+        } else {
+            File file = new File(filePath);
+            try (InputStream inputStream = new FileInputStream(file)) {
+                return inputStream;
+            }
+        }
+    }
 
 	public String getClientKeystorePath() {
 		return clientKeystorePath;

--- a/src/main/java/org/bcos/channel/handler/ChannelConnections.java
+++ b/src/main/java/org/bcos/channel/handler/ChannelConnections.java
@@ -1,8 +1,12 @@
 package org.bcos.channel.handler;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.security.KeyStore;
 import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -13,8 +17,8 @@ import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.security.cert.X509Certificate;
 
+import org.bcos.channel.dto.EthereumMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
@@ -22,7 +26,6 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
-import org.bcos.channel.dto.EthereumMessage;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
@@ -51,6 +54,20 @@ public class ChannelConnections {
 
 	public void setCaCertPath(String caCertPath) {
 		this.caCertPath = caCertPath;
+	}
+	
+	public InputStream getInputStream(String filePath) throws IOException{
+	    // if starts with "classpath:"
+	    if(filePath.startsWith("classpath:")){
+	        ResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+	        Resource caResource = resolver.getResource(filePath);
+	        return caResource.getInputStream();
+	    }
+	    else{
+            File file = new File(filePath); 
+            InputStream inputStream = new FileInputStream(file);
+            return inputStream;
+	    }
 	}
 
 	public String getClientKeystorePath() {
@@ -225,13 +242,7 @@ public class ChannelConnections {
                 @Override
                 public void initChannel(SocketChannel ch) throws Exception {
                     KeyStore ks = KeyStore.getInstance("JKS");
-                    
-                    ResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
-                    
-                    Resource keystoreResource = resolver.getResource(getClientKeystorePath());
-                    Resource caResource = resolver.getResource(getCaCertPath());
-
-					ks.load(keystoreResource.getInputStream(), getKeystorePassWord().toCharArray());
+					ks.load(getInputStream(getClientKeystorePath()), getKeystorePassWord().toCharArray());
                 	
                 	/*
                 	 * 每次连接使用新的handler
@@ -243,7 +254,7 @@ public class ChannelConnections {
                 	handler.setThreadPool(selfThreadPool);
                 	
                 	SslContext sslCtx = SslContextBuilder.forServer((PrivateKey)ks.getKey("client", getClientCertPassWord().toCharArray()), (X509Certificate)ks.getCertificate("client"))
-                			.trustManager(caResource.getFile())
+                			.trustManager(getInputStream(getCaCertPath()))
                 			.build();
                 	
                 	ch.pipeline().addLast(
@@ -315,15 +326,13 @@ public class ChannelConnections {
 		final ThreadPoolTaskExecutor selfThreadPool = threadPool;
 		
 		ResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
-		final Resource keystoreResource = resolver.getResource(getClientKeystorePath());
-        final Resource caResource = resolver.getResource(getCaCertPath());
         
 		bootstrap.handler(new ChannelInitializer<SocketChannel>() {
             @Override
             public void initChannel(SocketChannel ch) throws Exception {
             	KeyStore ks = KeyStore.getInstance("JKS");
-            	InputStream ksInputStream = keystoreResource.getInputStream();
-            	ks.load(ksInputStream, 	getKeystorePassWord().toCharArray());
+
+            	ks.load(getInputStream(getClientKeystorePath()), 	getKeystorePassWord().toCharArray());
 				/*
 				 * 每次连接使用新的handler 连接信息从socketChannel中获取
 				 */
@@ -332,7 +341,7 @@ public class ChannelConnections {
 				handler.setIsServer(false);
 				handler.setThreadPool(selfThreadPool);
 
-				SslContext sslCtx = SslContextBuilder.forClient().trustManager(caResource.getFile())
+				SslContext sslCtx = SslContextBuilder.forClient().trustManager(getInputStream(getCaCertPath()))
 						.keyManager((PrivateKey) ks.getKey("client", getClientCertPassWord().toCharArray()),
 								(X509Certificate) ks.getCertificate("client"))
 						.build();


### PR DESCRIPTION
原有的证书读取方式是通过ResourcePatternResolver，通过读取项目classpath的方式引入读取证书文件。但这种方式不兼容springboot jar的工程。因为在springboot的bootJar的工程中，是无法通过classpath读取文件的，而只能通过InputStream，解决方案就是增加FileSystem的方式读入文件的InputStream。