### PR TITLE
支持证书文件通过inputstream读取

### DIFF
--- a/src/main/java/org/bcos/channel/handler/ChannelConnections.java
+++ b/src/main/java/org/bcos/channel/handler/ChannelConnections.java
@@ -1,8 +1,12 @@
 package org.bcos.channel.handler;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.security.KeyStore;
 import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -13,8 +17,8 @@ import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.security.cert.X509Certificate;
 
+import org.bcos.channel.dto.EthereumMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
@@ -22,7 +26,6 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
-import org.bcos.channel.dto.EthereumMessage;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
@@ -51,6 +54,19 @@ public class ChannelConnections {
 
 	public void setCaCertPath(String caCertPath) {
 		this.caCertPath = caCertPath;
+	}
+	
+	public InputStream getInputStream(String filePath) throws IOException{
+	    if(filePath.startsWith("classpath") || filePath.startsWith("file:")){
+	        ResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+	        Resource caResource = resolver.getResource(filePath);
+	        return caResource.getInputStream();
+	    }
+	    else{
+            File file = new File(filePath); 
+            InputStream inputStream = new FileInputStream(file);
+            return inputStream;
+	    }
 	}
 
 	public String getClientKeystorePath() {
@@ -216,7 +232,8 @@ public class ChannelConnections {
 		final ChannelConnections selfService = this;
 		final ThreadPoolTaskExecutor selfThreadPool = threadPool;
 		
-		try {
+        try (InputStream clientKeystoreInputStream = getInputStream(getClientKeystorePath());
+                InputStream caInputStream = getInputStream(getCaCertPath());){
 			serverBootstrap.group(bossGroup, workerGroup)
 			.channel(NioServerSocketChannel.class)
             .option(ChannelOption.SO_BACKLOG, 100)
@@ -225,13 +242,7 @@ public class ChannelConnections {
                 @Override
                 public void initChannel(SocketChannel ch) throws Exception {
                     KeyStore ks = KeyStore.getInstance("JKS");
-                    
-                    ResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
-                    
-                    Resource keystoreResource = resolver.getResource(getClientKeystorePath());
-                    Resource caResource = resolver.getResource(getCaCertPath());
-
-					ks.load(keystoreResource.getInputStream(), getKeystorePassWord().toCharArray());
+					ks.load(clientKeystoreInputStream, getKeystorePassWord().toCharArray());
                 	
                 	/*
                 	 * 每次连接使用新的handler
@@ -243,7 +254,7 @@ public class ChannelConnections {
                 	handler.setThreadPool(selfThreadPool);
                 	
                 	SslContext sslCtx = SslContextBuilder.forServer((PrivateKey)ks.getKey("client", getClientCertPassWord().toCharArray()), (X509Certificate)ks.getCertificate("client"))
-                			.trustManager(caResource.getFile())
+                			.trustManager(caInputStream)
                 			.build();
                 	
                 	ch.pipeline().addLast(
@@ -315,15 +326,14 @@ public class ChannelConnections {
 		final ThreadPoolTaskExecutor selfThreadPool = threadPool;
 		
 		ResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
-		final Resource keystoreResource = resolver.getResource(getClientKeystorePath());
-        final Resource caResource = resolver.getResource(getCaCertPath());
         
 		bootstrap.handler(new ChannelInitializer<SocketChannel>() {
             @Override
             public void initChannel(SocketChannel ch) throws Exception {
             	KeyStore ks = KeyStore.getInstance("JKS");
-            	InputStream ksInputStream = keystoreResource.getInputStream();
-            	ks.load(ksInputStream, 	getKeystorePassWord().toCharArray());
+            	InputStream clientKeystoreInputStream = getInputStream(getClientKeystorePath());
+            	ks.load(clientKeystoreInputStream, 	getKeystorePassWord().toCharArray());
+            	clientKeystoreInputStream.close();
 				/*
 				 * 每次连接使用新的handler 连接信息从socketChannel中获取
 				 */
@@ -331,12 +341,13 @@ public class ChannelConnections {
 				handler.setConnections(selfService);
 				handler.setIsServer(false);
 				handler.setThreadPool(selfThreadPool);
-
-				SslContext sslCtx = SslContextBuilder.forClient().trustManager(caResource.getFile())
+				
+				InputStream caInputStream = getInputStream(getCaCertPath());
+				SslContext sslCtx = SslContextBuilder.forClient().trustManager(caInputStream)
 						.keyManager((PrivateKey) ks.getKey("client", getClientCertPassWord().toCharArray()),
 								(X509Certificate) ks.getCertificate("client"))
 						.build();
-
+				caInputStream.close();
 				ch.pipeline().addLast(sslCtx.newHandler(ch.alloc()),
 						new LengthFieldBasedFrameDecoder(1024 * 1024 * 4, 0, 4, -4, 0),
 						new IdleStateHandler(idleTimeout, idleTimeout, idleTimeout, TimeUnit.MILLISECONDS), handler);


### PR DESCRIPTION
在加载证书的时候，进行判断，如果是以classpath*或file:开始；则采用原有的方式读取；如果不是，则采用FileSystem读取InputStream。这样做的目的是为了兼容springboot在打包jar的时候，无法读取证书文件的问题。