### PR TITLE
同步交易接口，时间可配置

### DIFF
--- a/src/main/java/org/bcos/web3j/tx/TransactionManager.java
+++ b/src/main/java/org/bcos/web3j/tx/TransactionManager.java
@@ -10,6 +10,7 @@ import org.bcos.web3j.protocol.core.methods.response.EthGetTransactionReceipt;
 import org.bcos.web3j.protocol.core.methods.response.EthSendTransaction;
 import org.bcos.web3j.protocol.core.methods.response.TransactionReceipt;
 import org.bcos.web3j.protocol.exceptions.TransactionTimeoutException;
+import org.bcos.web3j.utils.AttemptsConf;
 
 /**
  * Transaction manager abstraction for executing transactions with Ethereum client via
@@ -17,8 +18,8 @@ import org.bcos.web3j.protocol.exceptions.TransactionTimeoutException;
  */
 public abstract class TransactionManager {
 
-    private static final int SLEEP_DURATION = 1500;
-    private static final int ATTEMPTS = 10;
+    private static final int SLEEP_DURATION = AttemptsConf.sleepDuration;
+    private static final int ATTEMPTS =  AttemptsConf.attempts;
 
     private final int sleepDuration;
     private final int attempts;
@@ -96,8 +97,8 @@ public abstract class TransactionManager {
         for (int i = 0; i < attempts; i++) {
 
             if (!receiptOptional.isPresent()) {
-                Thread.sleep(((long)sleepDuration*(i*i)+sleepDuration));
-                sumTime += (sleepDuration*(i*i)+sleepDuration);
+                Thread.sleep((long)sleepDuration);
+                sumTime += sleepDuration;
                 receiptOptional = sendTransactionReceiptRequest(transactionHash);
             } else {
                 return receiptOptional.get();

--- a/src/main/java/org/bcos/web3j/utils/AttemptsConf.java
+++ b/src/main/java/org/bcos/web3j/utils/AttemptsConf.java
@@ -1,0 +1,31 @@
+package org.bcos.web3j.utils;
+
+/**
+ * Created by mingzhenliu on 2018/8/24.
+ */
+public class AttemptsConf {
+    public static Integer sleepDuration = 1500;
+    public static Integer attempts  = 40;
+    public AttemptsConf(int sleepDuration,int attempts){
+        this.sleepDuration = sleepDuration;
+        this.attempts = attempts;
+    }
+
+    public int getSleepDuration() {
+        return sleepDuration;
+    }
+
+    public void setSleepDuration(int sleepDuration) {
+        AttemptsConf.sleepDuration = sleepDuration;
+    }
+
+    public int getAttempts() {
+        return attempts;
+    }
+
+    public void setAttempts(int attempts) {
+        AttemptsConf.attempts = attempts;
+    }
+
+}
+


### PR DESCRIPTION
轮询时间可配置，

<bean id="attemptsConf" class="org.bcos.web3j.utils.AttemptsConf">
		<constructor-arg  index="0" value="1500"/>
		<constructor-arg  index="1" value="40"/>
</bean>
配置代表每次间隔1500毫秒，总共轮询40次